### PR TITLE
Add prompt configuration for generation

### DIFF
--- a/configs/Generation.yaml
+++ b/configs/Generation.yaml
@@ -16,6 +16,8 @@ embed_dim: 256
 temp: 0.07
 k_test: 128
 
+prompt: 'a picture of '
+
 alpha: 0.4
 distill: True
 warm_up: True


### PR DESCRIPTION
## Summary
- add explicit prompt default in Generation config to support model initialization

## Testing
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_68b7d2d8a4c483218b8e4724708da2c7