### PR TITLE
Use raw string for regex pattern in BLIP tokenizer

### DIFF
--- a/generation_api/tokenizers_blip.py
+++ b/generation_api/tokenizers_blip.py
@@ -65,7 +65,7 @@ class Tokenizer(object):
             .replace('2.', '').replace('3.', '').replace('4.', '').replace('5.', '') \
             .replace('1、', '').replace('2、', '').replace('3、', '').replace('4、', '') \
             .strip().lower()
-        sent_cleaner = lambda t: re.sub('[.,?;*!%^&_+():-\[\]{}]', '', t.replace('"', '').replace('/', '').
+        sent_cleaner = lambda t: re.sub(r'[.,?;*!%^&_+():-\[\]{}]', '', t.replace('"', '').replace('/', '').
                                         replace('\\', '').replace("'", '').strip().lower())
         # jieba cut the tokens
         tokens = [sent_cleaner(sent) for sent in jieba.lcut(report_cleaner(report)) if sent_cleaner(sent) != []]


### PR DESCRIPTION
## Summary
- use raw string for punctuation-matching regex in BLIP tokenizer's `sent_cleaner`
- ensure regex literals use raw strings to prevent warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7d373516c8321b8361878da9f8719