### PR TITLE
Use basename for record file naming

### DIFF
--- a/generation_api/trainer_blip.py
+++ b/generation_api/trainer_blip.py
@@ -110,7 +110,8 @@ class BaseTrainer(object):
     def _save_file(self, log):
         if not os.path.exists(self.args.record_dir):
             os.makedirs(self.args.record_dir, exist_ok=True)
-        record_path = os.path.join(self.args.record_dir, self.args.dataset_name +'_'+self.args.save_dir.split('/')[2] +'.json')
+        save_name = os.path.basename(os.path.normpath(self.args.save_dir))
+        record_path = os.path.join(self.args.record_dir, f"{self.args.dataset_name}_{save_name}.json")
         with open(record_path, 'w') as f:
             json.dump(log, f)
 
@@ -125,7 +126,8 @@ class BaseTrainer(object):
 
         if not os.path.exists(self.args.record_dir):
             os.makedirs(self.args.record_dir)
-        record_path = os.path.join(self.args.record_dir, self.args.dataset_name+'_'+self.args.save_dir.split('/')[2] +'.csv')
+        save_name = os.path.basename(os.path.normpath(self.args.save_dir))
+        record_path = os.path.join(self.args.record_dir, f"{self.args.dataset_name}_{save_name}.csv")
         if not os.path.exists(record_path):
             record_table = pd.DataFrame()
         else:


### PR DESCRIPTION
## Summary
- avoid IndexError by constructing record filenames with os.path.basename
- use consistent basename logic for CSV best-score tracking

## Testing
- `python -m py_compile generation_api/trainer_blip.py`
- ⚠️ `python dummy training` *(failed: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c7a6fb879483218c3b74f9ed17de43